### PR TITLE
Add trove classifiers and requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,11 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
+        "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: CGI Tools/Libraries",
+        "Topic :: Software Development :: Libraries"
+    ],
+    install_requires=[
+            "requests>=2.25.1"
     ],
     python_requires='>=3.5',
 )


### PR DESCRIPTION
[Trove classifiers](https://pypi.org/classifiers/) will aid in people trying to find projects relating to HTTP APIs.

In addition, adding requirements to `setup.py` is best practice.