### PR TITLE
Feature / Bugfix - Implement a better Request/Response Handler, HttpError Exception, Parse_Response

### DIFF
--- a/pyblox3/src/abtesting.py
+++ b/pyblox3/src/abtesting.py
@@ -10,6 +10,7 @@ from .util import *
 
 root = "https://abtesting.roblox.com"
 
+Req = Req()
 
 class AbTesting_v1:
 

--- a/pyblox3/src/accountInformation.py
+++ b/pyblox3/src/accountInformation.py
@@ -7,7 +7,8 @@
 #
 
 from .util import *
-import json
+
+Req = Req()
 
 class accountInformation_v1:
 

--- a/pyblox3/src/auth.py
+++ b/pyblox3/src/auth.py
@@ -7,8 +7,8 @@
 #
 
 from .util import *
-import json
-import requests
+
+Req = Req()
 
 root = "https://auth.roblox.com"
 

--- a/pyblox3/src/games.py
+++ b/pyblox3/src/games.py
@@ -7,7 +7,8 @@
 #
 
 from .util import *
-import json
+
+Req = Req()
 
 class Games_v1:
 

--- a/pyblox3/src/groups.py
+++ b/pyblox3/src/groups.py
@@ -7,7 +7,8 @@
 #
 
 from .util import *
-import json
+
+Req = Req()
 
 class Groups_v1:
 

--- a/pyblox3/src/privateMessages.py
+++ b/pyblox3/src/privateMessages.py
@@ -7,7 +7,8 @@
 #
 
 from .util import *
-import json
+
+Req = Req()
 
 class privateMessages_v1:
 

--- a/pyblox3/src/users.py
+++ b/pyblox3/src/users.py
@@ -7,7 +7,8 @@
 #
 
 from .util import *
-import json
+
+Req = Req()
 
 class Users_v1:
 

--- a/pyblox3/src/util/__init__.py
+++ b/pyblox3/src/util/__init__.py
@@ -9,6 +9,9 @@
 # Some nifty methods that I like to keep handy because
 # I write them over and over for every project.
 # Bet you relate.. 
+#
+# Message from Sanjay 2024: Who the hell uses
+# the word nifty..?
 
 # Parent Class Modules
 from .req import Req

--- a/pyblox3/src/util/req.py
+++ b/pyblox3/src/util/req.py
@@ -8,8 +8,6 @@
 
 import httpx
 
-
-
 class HttpError(Exception):
 	"""
 	Base class that represents an HTTP Error in the form of an exception.

--- a/pyblox3/src/util/req.py
+++ b/pyblox3/src/util/req.py
@@ -6,33 +6,50 @@
 #  Copyright © 2019- Sanjay-B(Sanjay Bhadra). All rights reserved.
 #
 
-import asyncio
-import requests_async as requests
-import json
+import httpx
+
+
+
+class HttpError(Exception):
+	"""
+	Base class that represents an HTTP Error in the form of an exception.
+	"""
+	def __init__(self, kind="Generic", message="Generic Error", url="Somewhere"):
+		"""
+		Creates an exception with specified message.
+		If not message is provided, it defaults to "Generic Error".
+
+		@param kind: str. Represents the the kind of exception.
+		@param message: str. Represents the error message of the exception.
+		@param url: str. Represents the url the error occured at.
+		"""
+		self.kind = kind
+		self.message = message
+		self.url = url
+		super().__init__(self.message)
 
 
 class Req:
+	"""
+	Base class that holds HTTP request and response mechanisms.
+	"""
 
-	token = None
+	async def request(self, t: str, url: str, payload=None, header={}, cookies={}):
+		"""
+		Creates, executes and returns a request in the form of a response.
+		Throws an exception if conditions are not met. 
 
-	'''
-	@method 
-		request(t=String,url=String,*args,**kwargs)
+		@param t: Str. Type of request. ie. GET, POST, PATCH, DELETE or DEL.
+					   Can also be lowercase, snakecase, etc.
+		@param url: Str. URL to send the request.
+		@param payload: Dict or None. Represents the payload or data to send
+						the request with.
+		@param header: Dict. Represents the headers to send the request with.
+		@param cookies: Dict. Represents the cookies to send the request with.
 
-	@params 
-		t = Type of Request(GET or POST)
-		url = URL
-
-	@optionals 
-
-		payload = Dictionary Payload
-		header = Request Headers
-		cookies = cookie
-
-	@result 
-		Returns request response wholesale as a tuple
-
-	@example 1:
+		@return: Tuple.
+		
+		@example:
 
 		# GET Request
 		response = Req.request(t="GET",url="http://httpbin.org/get")
@@ -42,9 +59,8 @@ class Req:
 
 		# And so on... its a tuple so this also works as a shorthand:
 		response = Req.request(t="GET",url="http://httpbin.org/get")[0]
-
-
-	@example 2:
+		
+		@example:
 
 		# POST Request
 		data = {"Username":"JohnDoe","Password":"JaneDoe"}
@@ -57,30 +73,56 @@ class Req:
 
 		# Once again, this works as a shorthand:
 		response = Req.request(t="POST",url"http://httpbin.org/post",payload=data)[0]
-	'''
+		"""
+		async with httpx.AsyncClient(cookies=cookies) as client:
 
-	async def request(t=str,url=str,*args,**kwargs):
-		payload = kwargs.get('payload',None)
-		header = kwargs.get('header',{})
-		cookies = kwargs.get('cookies',{})
+			# TODO: Backwards Compatibility (will be renamed to this later)
+			kind = t.upper()
+			headers = header
+			
+			# Obtain our initial token (fresh)
+			response = await client.post(url="https://www.roblox.com/authentication/signoutfromallsessionsandreauthenticate", data=None, headers=headers)
+			csrf_token = response.headers.get("X-CSRF-TOKEN")
+			if not csrf_token:
+				raise HttpError("POST Request", "Initial X-CSRF-TOKEN was not found in headers, aborted", url)
+			
+			# Perform actual request
+			headers["X-CSRF-TOKEN"] = csrf_token
+			if kind == "GET":
+				response = await client.get(url, headers=headers)
+			elif kind == "POST":
+				if not cookies:
+					raise HttpError("POST Request", "Endpoint requires account cookie / authentication", url)
+				elif not payload:
+					raise HttpError("POST Request", "Endpoint requires payload / request body", url)
+				response = await client.post(url=url, data=payload, headers=headers)
+			elif kind == "PATCH":
+				if not cookies:
+					raise HttpError("PATCH Request", "Endpoint requires account cookie / authentication", url)
+				elif not payload:
+					raise HttpError("PATCH Request", "Endpoint requires payload / request body", url)
+				response = await client.patch(url=url, data=payload, headers=headers)
+			elif kind == ("DEL" or "DELETE"):
+				if not cookies:
+					raise HttpError("DELETE Request", "Endpoint requires account cookie / authentication", url)
+				response = await client.delete(url=url, payload=payload, headers=headers)
+			return self.parse_response(response)
+		
+	def parse_response(self, response):
+		"""
+		Parses respone into expected tuple format. 
 
-		if t == "GET" or "POST" or "PATCH" or "DEL":
-			method = t.replace('DEL', 'delete')
-			response = await requests.request("POST", "https://www.roblox.com/authentication/signoutfromallsessionsandreauthenticate", data=None, headers=header, cookies=cookies or {})
-			header['X-CSRF-TOKEN'] = response.headers['X-CSRF-TOKEN']
-			request = await requests.request(method, str(url), data=payload or None, headers=header, cookies=cookies)
-			statusCode = request.status_code
-			content = request.content
-			headers = request.headers
-			encoding = request.encoding
-			json = request.json()
+		@param response: Response. The response object from the request that has been performed.
 
-			# resend request with xcsrf token
-			if statusCode == 403 and 'X-CSRF-TOKEN' in headers:
-				kwargs['headers']['X-CSRF-TOKEN'] = headers['X-CSRF-TOKEN']
-				return await request(t=t, url=url, *args, **kwargs)
-
-			if statusCode == 200:
-				return statusCode, content, headers, encoding, json
-			else:
-				return statusCode, content, headers, encoding, json["errors"][0]
+		@return: tuple. If the status code is 200, the return is Tuple(status_code, content, headers, encoding, json).
+						If the status code is not 200, the return is Tuple(status_code, content, headers, encoding, json["errors"][0]).
+						Note that a status code of 200 means the request is successful. Otherwise, an error has occured.
+		"""
+		status_code = response.status_code
+		content = response.content
+		headers = response.headers
+		encoding = response.encoding
+		json = response.json()
+		if status_code == 200:
+			return status_code, content, headers, encoding, json
+		return status_code, content, headers, encoding, json["errors"][0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 aiohttp
 asyncio
-requests_async
+httpx
 pytest


### PR DESCRIPTION
It's been exactly, 2 years 7 months and 13 days (or 957 days if you prefer) since I've last updated this.

What this brings: 
- New implementation for Req class (056402d4d70f5a2754eda41e383e67a3351599dd)
    - Better, accurate documentation 
- New implementation for Req.request method (056402d4d70f5a2754eda41e383e67a3351599dd)
    - Externally the same, internally different
    - Backwards compatible, you don't have to change anything
- Implemented Req.parse_request method (056402d4d70f5a2754eda41e383e67a3351599dd)
- Implemented HttpError Exception (056402d4d70f5a2754eda41e383e67a3351599dd)

What this fixes: 
- Fixes `Cannot create a client socket with a PROTOCOL_TLS_SERVER context`  (056402d4d70f5a2754eda41e383e67a3351599dd)
    - Previously broke library for Python versions 3.8.x - current 
- Remove unused imports (056402d4d70f5a2754eda41e383e67a3351599dd)
- Removed space (a6c048664b7e3a938079aeedbb7542f764dc3bdf)

What this removes: 
- Dropped support for `requests_async` package (Deprecated since Sep 27, 2019). It's no longer compatible with the SSL version that Python 3.8+ supports. Supported versions are still Python 3.6+.  (1792cdbe6b41a8291e0a79204b4571aaf1fd91a2)

What is coming soon: 
- Documentation
    - Yes I know. I folded
- OpenCloud Support
- Oauth Support
- API Key Support
- Better Examples
- Better internal design
    - Sorry I made you read it 